### PR TITLE
feat: Add support for creating private services with VPC ingress connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,42 @@ module "app_runner_image_base" {
 }
 ```
 
+### Private AppRunner Service
+
+```hcl
+module "app_runner_private" {
+  source = "terraform-aws-modules/app-runner/aws"
+
+  service_name = "example-private"
+
+  ...
+
+  # Ingress
+  create_ingress_vpc_connection = true
+  ingress_vpc_id                = "vpc-12345678"
+  ingress_vpc_endpoint_id       = "vpce-01234567890123456 s"
+
+  # Egress
+  create_vpc_connector          = true
+  vpc_connector_subnets         = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
+  vpc_connector_security_groups = ["sg-12345678"]
+
+  network_configuration = {
+    ingress_configuration = {
+      is_publicly_accessible = false
+    }
+    egress_configuration = {
+      egress_type = "VPC"
+    }
+  }
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}
+```
+
 ## Examples
 
 Examples codified under the [`examples`](https://github.com/terraform-aws-modules/terraform-aws-app-runner/tree/master/examples) are intended to give users references for how to use the module(s) as well as testing/validating changes to the source code of the module. If contributing to the project, please be sure to make any appropriate updates to the relevant examples to allow maintainers to test your changes and to keep the examples up to date for users. Thank you!
@@ -145,13 +181,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.38 |
 
 ## Modules
 
@@ -167,6 +203,7 @@ No modules.
 | [aws_apprunner_observability_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_observability_configuration) | resource |
 | [aws_apprunner_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_service) | resource |
 | [aws_apprunner_vpc_connector.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_vpc_connector) | resource |
+| [aws_apprunner_vpc_ingress_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_vpc_ingress_connection) | resource |
 | [aws_iam_policy.access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -195,6 +232,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_access_iam_role"></a> [create\_access\_iam\_role](#input\_create\_access\_iam\_role) | Determines whether an IAM role is created or to use an existing IAM role | `bool` | `false` | no |
 | <a name="input_create_custom_domain_association"></a> [create\_custom\_domain\_association](#input\_create\_custom\_domain\_association) | Determines whether a Custom Domain Association will be created | `bool` | `false` | no |
+| <a name="input_create_ingress_vpc_connection"></a> [create\_ingress\_vpc\_connection](#input\_create\_ingress\_vpc\_connection) | Determines whether a VPC ingress configuration will be created | `bool` | `false` | no |
 | <a name="input_create_instance_iam_role"></a> [create\_instance\_iam\_role](#input\_create\_instance\_iam\_role) | Determines whether an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
 | <a name="input_create_service"></a> [create\_service](#input\_create\_service) | Determines whether the service will be created | `bool` | `true` | no |
 | <a name="input_create_vpc_connector"></a> [create\_vpc\_connector](#input\_create\_vpc\_connector) | Determines whether a VPC Connector will be created | `bool` | `false` | no |
@@ -203,6 +241,8 @@ No modules.
 | <a name="input_enable_www_subdomain"></a> [enable\_www\_subdomain](#input\_enable\_www\_subdomain) | Whether to associate the subdomain with the App Runner service in addition to the base domain. Defaults to `true` | `bool` | `null` | no |
 | <a name="input_encryption_configuration"></a> [encryption\_configuration](#input\_encryption\_configuration) | The encryption configuration for the service | `any` | `{}` | no |
 | <a name="input_health_check_configuration"></a> [health\_check\_configuration](#input\_health\_check\_configuration) | The health check configuration for the service | `any` | `{}` | no |
+| <a name="input_ingress_vpc_endpoint_id"></a> [ingress\_vpc\_endpoint\_id](#input\_ingress\_vpc\_endpoint\_id) | The ID of the VPC endpoint that is used for the VPC ingress configuration | `string` | `""` | no |
+| <a name="input_ingress_vpc_id"></a> [ingress\_vpc\_id](#input\_ingress\_vpc\_id) | The ID of the VPC that is used for the VPC ingress configuration | `string` | `""` | no |
 | <a name="input_instance_configuration"></a> [instance\_configuration](#input\_instance\_configuration) | The instance configuration for the service | `any` | `{}` | no |
 | <a name="input_instance_iam_role_description"></a> [instance\_iam\_role\_description](#input\_instance\_iam\_role\_description) | Description of the role | `string` | `null` | no |
 | <a name="input_instance_iam_role_name"></a> [instance\_iam\_role\_name](#input\_instance\_iam\_role\_name) | Name to use on IAM role created | `string` | `null` | no |
@@ -227,7 +267,7 @@ No modules.
 | <a name="output_access_iam_role_arn"></a> [access\_iam\_role\_arn](#output\_access\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
 | <a name="output_access_iam_role_name"></a> [access\_iam\_role\_name](#output\_access\_iam\_role\_name) | The name of the IAM role |
 | <a name="output_access_iam_role_unique_id"></a> [access\_iam\_role\_unique\_id](#output\_access\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
-| <a name="output_auto_scaling_configurations"></a> [auto\_scaling\_configurations](#output\_auto\_scaling\_configurations) | Map of attribute maps for all autosclaing configurations created |
+| <a name="output_auto_scaling_configurations"></a> [auto\_scaling\_configurations](#output\_auto\_scaling\_configurations) | Map of attribute maps for all autoscaling configurations created |
 | <a name="output_connections"></a> [connections](#output\_connections) | Map of attribute maps for all connections created |
 | <a name="output_custom_domain_association_certificate_validation_records"></a> [custom\_domain\_association\_certificate\_validation\_records](#output\_custom\_domain\_association\_certificate\_validation\_records) | A set of certificate CNAME records used for this domain name |
 | <a name="output_custom_domain_association_dns_target"></a> [custom\_domain\_association\_dns\_target](#output\_custom\_domain\_association\_dns\_target) | The App Runner subdomain of the App Runner service. The custom domain name is mapped to this target name. Attribute only available if resource created (not imported) with Terraform |
@@ -246,6 +286,8 @@ No modules.
 | <a name="output_vpc_connector_arn"></a> [vpc\_connector\_arn](#output\_vpc\_connector\_arn) | The Amazon Resource Name (ARN) of VPC connector |
 | <a name="output_vpc_connector_revision"></a> [vpc\_connector\_revision](#output\_vpc\_connector\_revision) | The revision of VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name |
 | <a name="output_vpc_connector_status"></a> [vpc\_connector\_status](#output\_vpc\_connector\_status) | The current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted |
+| <a name="output_vpc_ingress_connection_arn"></a> [vpc\_ingress\_connection\_arn](#output\_vpc\_ingress\_connection\_arn) | The Amazon Resource Name (ARN) of the VPC Ingress Connection |
+| <a name="output_vpc_ingress_connection_domain_name"></a> [vpc\_ingress\_connection\_domain\_name](#output\_vpc\_ingress\_connection\_domain\_name) | The domain name associated with the VPC Ingress Connection resource |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -34,13 +34,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.38 |
 
 ## Modules
 
@@ -49,9 +49,12 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_app_runner_code_base"></a> [app\_runner\_code\_base](#module\_app\_runner\_code\_base) | ../.. | n/a |
 | <a name="module_app_runner_disabled"></a> [app\_runner\_disabled](#module\_app\_runner\_disabled) | ../.. | n/a |
 | <a name="module_app_runner_image_base"></a> [app\_runner\_image\_base](#module\_app\_runner\_image\_base) | ../.. | n/a |
+| <a name="module_app_runner_private"></a> [app\_runner\_private](#module\_app\_runner\_private) | ../.. | n/a |
 | <a name="module_app_runner_shared_configs"></a> [app\_runner\_shared\_configs](#module\_app\_runner\_shared\_configs) | ../.. | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | n/a |
+| <a name="module_vpc_endpoints_security_group"></a> [vpc\_endpoints\_security\_group](#module\_vpc\_endpoints\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 
 ## Resources
 
@@ -90,6 +93,8 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="output_code_base_vpc_connector_arn"></a> [code\_base\_vpc\_connector\_arn](#output\_code\_base\_vpc\_connector\_arn) | The Amazon Resource Name (ARN) of VPC connector |
 | <a name="output_code_base_vpc_connector_revision"></a> [code\_base\_vpc\_connector\_revision](#output\_code\_base\_vpc\_connector\_revision) | The revision of VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name |
 | <a name="output_code_base_vpc_connector_status"></a> [code\_base\_vpc\_connector\_status](#output\_code\_base\_vpc\_connector\_status) | The current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted |
+| <a name="output_code_base_vpc_ingress_connection_arn"></a> [code\_base\_vpc\_ingress\_connection\_arn](#output\_code\_base\_vpc\_ingress\_connection\_arn) | The Amazon Resource Name (ARN) of the VPC Ingress Connection |
+| <a name="output_code_base_vpc_ingress_connection_domain_name"></a> [code\_base\_vpc\_ingress\_connection\_domain\_name](#output\_code\_base\_vpc\_ingress\_connection\_domain\_name) | The domain name associated with the VPC Ingress Connection resource |
 | <a name="output_connections"></a> [connections](#output\_connections) | Map of attribute maps for all connections created |
 | <a name="output_image_base_access_iam_role_arn"></a> [image\_base\_access\_iam\_role\_arn](#output\_image\_base\_access\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
 | <a name="output_image_base_access_iam_role_name"></a> [image\_base\_access\_iam\_role\_name](#output\_image\_base\_access\_iam\_role\_name) | The name of the IAM role |
@@ -111,6 +116,30 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="output_image_base_vpc_connector_arn"></a> [image\_base\_vpc\_connector\_arn](#output\_image\_base\_vpc\_connector\_arn) | The Amazon Resource Name (ARN) of VPC connector |
 | <a name="output_image_base_vpc_connector_revision"></a> [image\_base\_vpc\_connector\_revision](#output\_image\_base\_vpc\_connector\_revision) | The revision of VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name |
 | <a name="output_image_base_vpc_connector_status"></a> [image\_base\_vpc\_connector\_status](#output\_image\_base\_vpc\_connector\_status) | The current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted |
+| <a name="output_image_base_vpc_ingress_connection_arn"></a> [image\_base\_vpc\_ingress\_connection\_arn](#output\_image\_base\_vpc\_ingress\_connection\_arn) | The Amazon Resource Name (ARN) of the VPC Ingress Connection |
+| <a name="output_image_base_vpc_ingress_connection_domain_name"></a> [image\_base\_vpc\_ingress\_connection\_domain\_name](#output\_image\_base\_vpc\_ingress\_connection\_domain\_name) | The domain name associated with the VPC Ingress Connection resource |
+| <a name="output_private_access_iam_role_arn"></a> [private\_access\_iam\_role\_arn](#output\_private\_access\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
+| <a name="output_private_access_iam_role_name"></a> [private\_access\_iam\_role\_name](#output\_private\_access\_iam\_role\_name) | The name of the IAM role |
+| <a name="output_private_access_iam_role_unique_id"></a> [private\_access\_iam\_role\_unique\_id](#output\_private\_access\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_private_custom_domain_association_certificate_validation_records"></a> [private\_custom\_domain\_association\_certificate\_validation\_records](#output\_private\_custom\_domain\_association\_certificate\_validation\_records) | A set of certificate CNAME records used for this domain name |
+| <a name="output_private_custom_domain_association_dns_target"></a> [private\_custom\_domain\_association\_dns\_target](#output\_private\_custom\_domain\_association\_dns\_target) | The App Runner subdomain of the App Runner service. The custom domain name is mapped to this target name. Attribute only available if resource created (not imported) with Terraform |
+| <a name="output_private_custom_domain_association_id"></a> [private\_custom\_domain\_association\_id](#output\_private\_custom\_domain\_association\_id) | The `domain_name` and `service_arn` separated by a comma (`,`) |
+| <a name="output_private_instance_iam_role_arn"></a> [private\_instance\_iam\_role\_arn](#output\_private\_instance\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
+| <a name="output_private_instance_iam_role_name"></a> [private\_instance\_iam\_role\_name](#output\_private\_instance\_iam\_role\_name) | The name of the IAM role |
+| <a name="output_private_instance_iam_role_unique_id"></a> [private\_instance\_iam\_role\_unique\_id](#output\_private\_instance\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_private_observability_configuration_arn"></a> [private\_observability\_configuration\_arn](#output\_private\_observability\_configuration\_arn) | ARN of this observability configuration |
+| <a name="output_private_observability_configuration_latest"></a> [private\_observability\_configuration\_latest](#output\_private\_observability\_configuration\_latest) | Whether the observability configuration has the highest `observability_configuration_revision` among all configurations that share the same `observability_configuration_name` |
+| <a name="output_private_observability_configuration_revision"></a> [private\_observability\_configuration\_revision](#output\_private\_observability\_configuration\_revision) | The revision of the observability configuration |
+| <a name="output_private_observability_configuration_status"></a> [private\_observability\_configuration\_status](#output\_private\_observability\_configuration\_status) | The current state of the observability configuration. An `INACTIVE` configuration revision has been deleted and can't be used. It is permanently removed some time after deletion |
+| <a name="output_private_service_arn"></a> [private\_service\_arn](#output\_private\_service\_arn) | The Amazon Resource Name (ARN) of the service |
+| <a name="output_private_service_id"></a> [private\_service\_id](#output\_private\_service\_id) | An alphanumeric ID that App Runner generated for this service. Unique within the AWS Region |
+| <a name="output_private_service_status"></a> [private\_service\_status](#output\_private\_service\_status) | The current state of the App Runner service |
+| <a name="output_private_service_url"></a> [private\_service\_url](#output\_private\_service\_url) | A subdomain URL that App Runner generated for this service. You can use this URL to access your service web application |
+| <a name="output_private_vpc_connector_arn"></a> [private\_vpc\_connector\_arn](#output\_private\_vpc\_connector\_arn) | The Amazon Resource Name (ARN) of VPC connector |
+| <a name="output_private_vpc_connector_revision"></a> [private\_vpc\_connector\_revision](#output\_private\_vpc\_connector\_revision) | The revision of VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name |
+| <a name="output_private_vpc_connector_status"></a> [private\_vpc\_connector\_status](#output\_private\_vpc\_connector\_status) | The current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted |
+| <a name="output_private_vpc_ingress_connection_arn"></a> [private\_vpc\_ingress\_connection\_arn](#output\_private\_vpc\_ingress\_connection\_arn) | The Amazon Resource Name (ARN) of the VPC Ingress Connection |
+| <a name="output_private_vpc_ingress_connection_domain_name"></a> [private\_vpc\_ingress\_connection\_domain\_name](#output\_private\_vpc\_ingress\_connection\_domain\_name) | The domain name associated with the VPC Ingress Connection resource |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-app-runner/blob/master/LICENSE).

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -66,6 +66,16 @@ output "code_base_instance_iam_role_unique_id" {
   value       = module.app_runner_code_base.instance_iam_role_unique_id
 }
 
+output "code_base_vpc_ingress_connection_arn" {
+  description = "The Amazon Resource Name (ARN) of the VPC Ingress Connection"
+  value       = module.app_runner_code_base.vpc_ingress_connection_arn
+}
+
+output "code_base_vpc_ingress_connection_domain_name" {
+  description = "The domain name associated with the VPC Ingress Connection resource"
+  value       = module.app_runner_code_base.vpc_ingress_connection_domain_name
+}
+
 output "code_base_custom_domain_association_id" {
   description = "The `domain_name` and `service_arn` separated by a comma (`,`)"
   value       = module.app_runner_code_base.custom_domain_association_id
@@ -170,6 +180,16 @@ output "image_base_instance_iam_role_unique_id" {
   value       = module.app_runner_image_base.instance_iam_role_unique_id
 }
 
+output "image_base_vpc_ingress_connection_arn" {
+  description = "The Amazon Resource Name (ARN) of the VPC Ingress Connection"
+  value       = module.app_runner_image_base.vpc_ingress_connection_arn
+}
+
+output "image_base_vpc_ingress_connection_domain_name" {
+  description = "The domain name associated with the VPC Ingress Connection resource"
+  value       = module.app_runner_image_base.vpc_ingress_connection_domain_name
+}
+
 output "image_base_custom_domain_association_id" {
   description = "The `domain_name` and `service_arn` separated by a comma (`,`)"
   value       = module.app_runner_image_base.custom_domain_association_id
@@ -218,4 +238,118 @@ output "image_base_observability_configuration_latest" {
 output "image_base_observability_configuration_status" {
   description = "The current state of the observability configuration. An `INACTIVE` configuration revision has been deleted and can't be used. It is permanently removed some time after deletion"
   value       = module.app_runner_image_base.observability_configuration_status
+}
+
+################################################################################
+# Private
+################################################################################
+
+output "private_service_arn" {
+  description = "The Amazon Resource Name (ARN) of the service"
+  value       = module.app_runner_private.service_arn
+}
+
+output "private_service_id" {
+  description = "An alphanumeric ID that App Runner generated for this service. Unique within the AWS Region"
+  value       = module.app_runner_private.service_id
+}
+
+output "private_service_url" {
+  description = "A subdomain URL that App Runner generated for this service. You can use this URL to access your service web application"
+  value       = module.app_runner_private.service_url
+}
+
+output "private_service_status" {
+  description = "The current state of the App Runner service"
+  value       = module.app_runner_private.service_status
+}
+
+output "private_access_iam_role_name" {
+  description = "The name of the IAM role"
+  value       = module.app_runner_private.access_iam_role_name
+}
+
+output "private_access_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the IAM role"
+  value       = module.app_runner_private.access_iam_role_arn
+}
+
+output "private_access_iam_role_unique_id" {
+  description = "Stable and unique string identifying the IAM role"
+  value       = module.app_runner_private.access_iam_role_unique_id
+}
+
+output "private_instance_iam_role_name" {
+  description = "The name of the IAM role"
+  value       = module.app_runner_private.instance_iam_role_name
+}
+
+output "private_instance_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the IAM role"
+  value       = module.app_runner_private.instance_iam_role_arn
+}
+
+output "private_instance_iam_role_unique_id" {
+  description = "Stable and unique string identifying the IAM role"
+  value       = module.app_runner_private.instance_iam_role_unique_id
+}
+
+output "private_vpc_ingress_connection_arn" {
+  description = "The Amazon Resource Name (ARN) of the VPC Ingress Connection"
+  value       = module.app_runner_private.vpc_ingress_connection_arn
+}
+
+output "private_vpc_ingress_connection_domain_name" {
+  description = "The domain name associated with the VPC Ingress Connection resource"
+  value       = module.app_runner_private.vpc_ingress_connection_domain_name
+}
+
+output "private_custom_domain_association_id" {
+  description = "The `domain_name` and `service_arn` separated by a comma (`,`)"
+  value       = module.app_runner_private.custom_domain_association_id
+}
+
+output "private_custom_domain_association_certificate_validation_records" {
+  description = "A set of certificate CNAME records used for this domain name"
+  value       = module.app_runner_private.custom_domain_association_certificate_validation_records
+}
+
+output "private_custom_domain_association_dns_target" {
+  description = "The App Runner subdomain of the App Runner service. The custom domain name is mapped to this target name. Attribute only available if resource created (not imported) with Terraform"
+  value       = module.app_runner_private.custom_domain_association_dns_target
+}
+
+output "private_vpc_connector_arn" {
+  description = "The Amazon Resource Name (ARN) of VPC connector"
+  value       = module.app_runner_private.vpc_connector_arn
+}
+
+output "private_vpc_connector_status" {
+  description = "The current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted"
+  value       = module.app_runner_private.vpc_connector_status
+}
+
+output "private_vpc_connector_revision" {
+  description = "The revision of VPC connector. It's unique among all the active connectors (\"Status\": \"ACTIVE\") that share the same Name"
+  value       = module.app_runner_private.vpc_connector_revision
+}
+
+output "private_observability_configuration_arn" {
+  description = "ARN of this observability configuration"
+  value       = module.app_runner_private.observability_configuration_arn
+}
+
+output "private_observability_configuration_revision" {
+  description = "The revision of the observability configuration"
+  value       = module.app_runner_private.observability_configuration_revision
+}
+
+output "private_observability_configuration_latest" {
+  description = "Whether the observability configuration has the highest `observability_configuration_revision` among all configurations that share the same `observability_configuration_name`"
+  value       = module.app_runner_private.observability_configuration_latest
+}
+
+output "private_observability_configuration_status" {
+  description = "The current state of the observability configuration. An `INACTIVE` configuration revision has been deleted and can't be used. It is permanently removed some time after deletion"
+  value       = module.app_runner_private.observability_configuration_status
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 4.38"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,6 +61,20 @@ output "instance_iam_role_unique_id" {
 }
 
 ################################################################################
+# VPC Ingress Configuration
+################################################################################
+
+output "vpc_ingress_connection_arn" {
+  description = "The Amazon Resource Name (ARN) of the VPC Ingress Connection"
+  value       = try(aws_apprunner_vpc_ingress_connection.this[0].arn, null)
+}
+
+output "vpc_ingress_connection_domain_name" {
+  description = "The domain name associated with the VPC Ingress Connection resource"
+  value       = try(aws_apprunner_vpc_ingress_connection.this[0].domain_name, null)
+}
+
+################################################################################
 # Custom Domain Association
 ################################################################################
 
@@ -112,7 +126,7 @@ output "connections" {
 ################################################################################
 
 output "auto_scaling_configurations" {
-  description = "Map of attribute maps for all autosclaing configurations created"
+  description = "Map of attribute maps for all autoscaling configurations created"
   value       = aws_apprunner_auto_scaling_configuration_version.this
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,28 @@ variable "instance_iam_role_policies" {
 }
 
 ################################################################################
+# VPC Ingress Configuration
+################################################################################
+
+variable "create_ingress_vpc_connection" {
+  description = "Determines whether a VPC ingress configuration will be created"
+  type        = bool
+  default     = false
+}
+
+variable "ingress_vpc_id" {
+  description = "The ID of the VPC that is used for the VPC ingress configuration"
+  type        = string
+  default     = ""
+}
+
+variable "ingress_vpc_endpoint_id" {
+  description = "The ID of the VPC endpoint that is used for the VPC ingress configuration"
+  type        = string
+  default     = ""
+}
+
+################################################################################
 # Custom Domain Association
 ################################################################################
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 4.38"
     }
   }
 }


### PR DESCRIPTION
## Description
- Add support for creating private services with VPC ingress connection
	- Ref: https://github.com/hashicorp/terraform-provider-aws/pull/27600

## Motivation and Context
- Allows users to create private services to be used within a VPC and not publicly accessible

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
