### PR TITLE
feat: Add support for runtime_environment_secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.77.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ module "app_runner_image_base" {
   # From shared configs
   auto_scaling_configuration_arn = module.app_runner_shared_configs.auto_scaling_configurations["mega"].arn
 
-  # Creating IAM instance profile to access secrets
-  create_instance_iam_role = true
-  instance_iam_role_policies = {
-    secrets_policy = aws_iam_policy.instance_policy.arn
+  # IAM instance profile permissions to access secrets
+  instance_policy_statements = {
+    GetSecretValue = {
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = [aws_secretsmanager_secret.this.arn]
+    }
   }
 
   source_configuration = {
@@ -119,7 +121,7 @@ module "app_runner_image_base" {
           MY_VARIABLE = "hello!"
         }
         runtime_environment_secrets = {
-          MY_SECRET = aws_secretsmanager_secret.example_secret.arn
+          MY_SECRET = aws_secretsmanager_secret.this.arn
         }
       }
       image_identifier      = "public.ecr.aws/aws-containers/hello-app-runner:latest"

--- a/README.md
+++ b/README.md
@@ -217,14 +217,17 @@ No modules.
 | [aws_apprunner_vpc_connector.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_vpc_connector) | resource |
 | [aws_apprunner_vpc_ingress_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_vpc_ingress_connection) | resource |
 | [aws_iam_policy.access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.access_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.instance_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.instance_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.access_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.instance_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
@@ -262,6 +265,7 @@ No modules.
 | <a name="input_instance_iam_role_permissions_boundary"></a> [instance\_iam\_role\_permissions\_boundary](#input\_instance\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_instance_iam_role_policies"></a> [instance\_iam\_role\_policies](#input\_instance\_iam\_role\_policies) | IAM policies to attach to the IAM role | `map(string)` | `{}` | no |
 | <a name="input_instance_iam_role_use_name_prefix"></a> [instance\_iam\_role\_use\_name\_prefix](#input\_instance\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `true` | no |
+| <a name="input_instance_policy_statements"></a> [instance\_policy\_statements](#input\_instance\_policy\_statements) | A map of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for custom permission usage | `any` | `{}` | no |
 | <a name="input_network_configuration"></a> [network\_configuration](#input\_network\_configuration) | The network configuration for the service | `any` | `{}` | no |
 | <a name="input_observability_configuration"></a> [observability\_configuration](#input\_observability\_configuration) | The observability configuration for the service | `any` | `{}` | no |
 | <a name="input_private_ecr_arn"></a> [private\_ecr\_arn](#input\_private\_ecr\_arn) | The ARN of the private ECR repository that contains the service image to launch | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -104,11 +104,23 @@ module "app_runner_image_base" {
   # From shared configs
   auto_scaling_configuration_arn = module.app_runner_shared_configs.auto_scaling_configurations["mega"].arn
 
+  # Creating IAM instance profile to access secrets
+  create_instance_iam_role = true
+  instance_iam_role_policies = {
+    secrets_policy = aws_iam_policy.instance_policy.arn
+  }
+
   source_configuration = {
     auto_deployments_enabled = false
     image_repository = {
       image_configuration = {
         port = 8000
+        runtime_environment_variables = {
+          MY_VARIABLE = "hello!"
+        }
+        runtime_environment_secrets = {
+          MY_SECRET = aws_secretsmanager_secret.example_secret.arn
+        }
       }
       image_identifier      = "public.ecr.aws/aws-containers/hello-app-runner:latest"
       image_repository_type = "ECR_PUBLIC"
@@ -181,13 +193,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.51 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.38 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.51 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -35,13 +35,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.51 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.38 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.51 |
 
 ## Modules
 
@@ -61,11 +61,9 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.instance_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_secretsmanager_secret.example_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_version.example_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_iam_policy_document.secrets_access_policy_content](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -10,6 +10,7 @@ Configuration in this directory creates:
 - An image based AppRunner service
   - Utilizes "mega" autoscaling configuration created in shared configs
   - Creates a VPC connector to the associated VPC private subnets
+  - Creates an example runtime environment variable and secret
 
 ## Usage
 
@@ -60,7 +61,11 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.instance_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_secretsmanager_secret.example_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.example_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_iam_policy_document.secrets_access_policy_content](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38"
+      version = ">= 4.51"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_apprunner_service" "this" {
   }
 
   dynamic "instance_configuration" {
-    for_each = length(var.instance_configuration) > 0 ? [var.instance_configuration] : []
+    for_each = length(var.instance_configuration) > 0 ? [var.instance_configuration] : (var.create_instance_iam_role ? [{ instance_role_arn = aws_iam_role.instance[0].arn }] : [])
 
     content {
       cpu               = try(instance_configuration.value.cpu, null)
@@ -111,6 +111,7 @@ resource "aws_apprunner_service" "this" {
                   port                          = try(code_configuration_values.value.port, null)
                   runtime                       = code_configuration_values.value.runtime
                   runtime_environment_variables = try(code_configuration_values.value.runtime_environment_variables, {})
+                  runtime_environment_secrets   = try(code_configuration_values.value.runtime_environment_secrets, {})
                   start_command                 = try(code_configuration_values.value.start_command, null)
                 }
               }
@@ -142,6 +143,7 @@ resource "aws_apprunner_service" "this" {
             content {
               port                          = try(image_configuration.value.port, null)
               runtime_environment_variables = try(image_configuration.value.runtime_environment_variables, {})
+              runtime_environment_secrets   = try(image_configuration.value.runtime_environment_secrets, {})
               start_command                 = try(image_configuration.value.start_command, null)
             }
           }

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,29 @@ data "aws_partition" "current" {}
 
 locals {
   create_service = var.create && var.create_service
+
+  # Ensure instance role created is attached even if no values are provided via `var.instance_configuration`
+  instance_configuration = local.create_instance_iam_role ? merge(
+    var.instance_configuration,
+    { instance_role_arn = aws_iam_role.instance[0].arn }
+  ) : var.instance_configuration
+
+  # Ensure access role created is attached even if no values are provided via `var.source_configuration`
+  source_configuration = local.create_access_iam_role ? merge(
+    var.source_configuration,
+    { authentication_configuration = { access_role_arn = aws_iam_role.access[0].arn } }
+  ) : var.source_configuration
+
+  # Ensure VPC connector created is attached even if no values are provided via `var.network_configuration`
+  network_configuration = local.create_vpc_connector ? merge(
+    var.network_configuration,
+    {
+      egress_configuration = {
+        egress_type       = "VPC"
+        vpc_connector_arn = aws_apprunner_vpc_connector.this[0].arn
+      }
+    }
+  ) : var.network_configuration
 }
 
 resource "aws_apprunner_service" "this" {
@@ -35,17 +58,17 @@ resource "aws_apprunner_service" "this" {
   }
 
   dynamic "instance_configuration" {
-    for_each = length(var.instance_configuration) > 0 ? [var.instance_configuration] : (var.create_instance_iam_role ? [{ instance_role_arn = aws_iam_role.instance[0].arn }] : [])
+    for_each = length(local.instance_configuration) > 0 ? [local.instance_configuration] : []
 
     content {
       cpu               = try(instance_configuration.value.cpu, null)
-      instance_role_arn = var.create_instance_iam_role ? aws_iam_role.instance[0].arn : lookup(instance_configuration.value, "instance_role_arn", null)
+      instance_role_arn = lookup(instance_configuration.value, "instance_role_arn", null)
       memory            = try(instance_configuration.value.memory, null)
     }
   }
 
   dynamic "network_configuration" {
-    for_each = length(var.network_configuration) > 0 ? [var.network_configuration] : []
+    for_each = length(local.network_configuration) > 0 ? [local.network_configuration] : []
 
     content {
       dynamic "ingress_configuration" {
@@ -61,7 +84,7 @@ resource "aws_apprunner_service" "this" {
 
         content {
           egress_type       = try(egress_configuration.value.egress_type, "VPC")
-          vpc_connector_arn = try(egress_configuration.value.vpc_connector_arn, aws_apprunner_vpc_connector.this[0].arn, null)
+          vpc_connector_arn = try(egress_configuration.value.vpc_connector_arn, null)
         }
       }
     }
@@ -78,16 +101,15 @@ resource "aws_apprunner_service" "this" {
 
   service_name = var.service_name
 
-
   dynamic "source_configuration" {
-    for_each = [var.source_configuration]
+    for_each = [local.source_configuration]
 
     content {
       dynamic "authentication_configuration" {
         for_each = try([source_configuration.value.authentication_configuration], [])
 
         content {
-          access_role_arn = var.create_access_iam_role ? aws_iam_role.access[0].arn : try(authentication_configuration.value.access_role_arn, null)
+          access_role_arn = lookup(authentication_configuration.value, "access_role_arn", null)
           connection_arn  = try(authentication_configuration.value.connection_arn, null)
         }
       }
@@ -301,6 +323,79 @@ resource "aws_iam_role_policy_attachment" "instance_additional" {
   for_each = { for k, v in var.instance_iam_role_policies : k => v if local.create_instance_iam_role }
 
   policy_arn = each.value
+  role       = aws_iam_role.instance[0].name
+}
+
+################################################################################
+# IAM Role Policy - Instance
+################################################################################
+
+locals {
+  create_instance_role_policy = local.create_instance_iam_role && length(var.instance_policy_statements) > 0
+}
+
+data "aws_iam_policy_document" "instance" {
+  count = local.create_instance_role_policy ? 1 : 0
+
+  dynamic "statement" {
+    for_each = var.instance_policy_statements
+
+    content {
+      sid           = try(statement.value.sid, statement.key)
+      actions       = try(statement.value.actions, null)
+      not_actions   = try(statement.value.not_actions, null)
+      effect        = try(statement.value.effect, null)
+      resources     = try(statement.value.resources, null)
+      not_resources = try(statement.value.not_resources, null)
+
+      dynamic "principals" {
+        for_each = try(statement.value.principals, [])
+
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+
+      dynamic "not_principals" {
+        for_each = try(statement.value.not_principals, [])
+
+        content {
+          type        = not_principals.value.type
+          identifiers = not_principals.value.identifiers
+        }
+      }
+
+      dynamic "condition" {
+        for_each = try(statement.value.conditions, [])
+
+        content {
+          test     = condition.value.test
+          values   = condition.value.values
+          variable = condition.value.variable
+        }
+      }
+    }
+  }
+}
+
+resource "aws_iam_policy" "instance" {
+  count = local.create_instance_role_policy ? 1 : 0
+
+  name        = var.instance_iam_role_use_name_prefix ? null : local.instance_iam_role_name
+  name_prefix = var.instance_iam_role_use_name_prefix ? "${local.instance_iam_role_name}-" : null
+  path        = var.instance_iam_role_path
+  description = var.instance_iam_role_description
+
+  policy = data.aws_iam_policy_document.instance[0].json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "instance" {
+  count = local.create_instance_role_policy ? 1 : 0
+
+  policy_arn = aws_iam_policy.instance[0].arn
   role       = aws_iam_role.instance[0].name
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,16 @@ variable "instance_iam_role_policies" {
 }
 
 ################################################################################
+# IAM Role Policy - Instance
+################################################################################
+
+variable "instance_policy_statements" {
+  description = "A map of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for custom permission usage"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # VPC Ingress Configuration
 ################################################################################
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38"
+      version = ">= 4.51"
     }
   }
 }


### PR DESCRIPTION
## Description

### Changes in `main.tf` - supporting `runtime_environment_secrets`

*Lines 114, 146* 

Add the `runtime_environment_secrets` map to `aws_apprunner_service`, if provided. Following exactly the same syntax as existing lines for `runtime_environment_variables`.

This map expects the desired name of a secret for your app runner as the KEY, and the ARN of that secret (as per your Secrets Manager or Systems Manager param store).

### Changes in `main.tf` - fixing `create_iam_instance_role`

*Line 38*

With the previous code, `create_instance_iam_role` in my view does not work as expected - it may get created if set to true, but only gets properly applied *if* the user also chose to provide an `instance_configuration`, as the role ARN for the instance profile of your app runner service is set inside that object. If the user does not provide any `instance_configuration` objects, the IAM role doesn't get linked to the App Runner service (regardless of `create_instance_iam_role` being true).

This change had to be made as after adding the initial bits to send secrets and trying it out, App Runner replied with:
```bash
Error: error creating App Runner Service (ex-complete-image-base): InvalidRequestException: Instance Role have to be provided if passing in RuntimeEnvironmentSecrets.
    with module.app_runner_image_base.aws_apprunner_service.this[0],
    on ../../main.tf line 11, in resource "aws_apprunner_service" "this":
    11: resource "aws_apprunner_service" "this" {
```

As mentioned in [AWS docs for secrets with App Runner](https://docs.aws.amazon.com/apprunner/latest/dg/env-variable.html), in order to provide `runtime_environment_secrets`, it is mandatory to provide also an IAM instance profile. This effectively means that the user has to set `create_instance_iam_role = true` when they want to provide runtime environment secrets, but if they forgo creating an `instance_configuration`, the apply fails anyway. The change addresses this problem.

**If you have suggestions how we could enforce this - i.e. fail `terraform validate` if `create_instance_iam_role=false` when providing environment secrets, I'm happy to add that in as well.**

### Changes in `versions.tf` - bumping AWS provider minimum version to `4.51`

The relevant change to the provider itself to support environment secrets was done in this version, see [closed PR #28871 in `terraform-provider-aws` adding support to `aws_apprunner_service` object in v4.51](https://github.com/hashicorp/terraform-provider-aws/pull/28871).

## Motivation and Context

It is a very common use case for App Runner users to need to provide runtime secrets, and as this is already supported by the AWS Terraform provider, it is relatively straightforward for us to also add this in to the module.

As this is a relatively minor change, I just extended the complete examples and added the relevant parameters to the 2 image-based examples (as the GitHub-based one would override the values from the hello-app-runner repo). I've executed the example and it seems to work. 

As the examples didn't currently cover `runtime_environment_variables`, I thought it best to add those in as well as the functionality is very similar and they show up in the same spot in the App Runner console.

## Breaking Changes

I don't believe so.

## How Has This Been Tested?

* [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
* [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
* [x] I have executed `pre-commit run -a` on my pull request

## References

* [Announcement from AWS adding support for the feature](https://aws.amazon.com/about-aws/whats-new/2023/01/aws-app-runner-secrets-configuration-aws-secrets-systems-manager/)
* [AWS App Runner docs on managing environment variables and secrets](https://docs.aws.amazon.com/apprunner/latest/dg/env-variable-manage.html#env-variable-manage.api)
* [AWS App Runner docs on referencing environment variables](https://docs.aws.amazon.com/apprunner/latest/dg/env-variable.html)