### PR TITLE
fix: Inconsistent conditional result types 

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -51,6 +51,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_app_runner_disabled"></a> [app\_runner\_disabled](#module\_app\_runner\_disabled) | ../.. | n/a |
 | <a name="module_app_runner_image_base"></a> [app\_runner\_image\_base](#module\_app\_runner\_image\_base) | ../.. | n/a |
 | <a name="module_app_runner_private"></a> [app\_runner\_private](#module\_app\_runner\_private) | ../.. | n/a |
+| <a name="module_app_runner_private_image_base"></a> [app\_runner\_private\_image\_base](#module\_app\_runner\_private\_image\_base) | ../.. | n/a |
 | <a name="module_app_runner_shared_configs"></a> [app\_runner\_shared\_configs](#module\_app\_runner\_shared\_configs) | ../.. | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -147,6 +147,33 @@ module "app_runner_image_base" {
   tags = local.tags
 }
 
+module "app_runner_private_image_base" {
+  source = "../.."
+
+  service_name = "${local.name}-image-base"
+
+  # Pulling from shared configs
+  auto_scaling_configuration_arn = module.app_runner_shared_configs.auto_scaling_configurations["min"].arn
+
+  source_configuration = {
+    auto_deployments_enabled = false
+    image_repository = {
+      image_configuration = {
+        port = 8000
+        runtime_environment_variables = {
+          MY_VARIABLE = "hello!"
+        }
+      }
+      create_access_iam_role  = true
+      image_repository_type   = "ECR"
+      image_identifier        = "12345678912.dkr.ecr.us-east-1.amazonaws.com/hello-app-runner:latest"
+      private_ecr_arn         = "arn:aws:ecr:us-east-1:123456789012:repository/hello-app-runner"
+    }
+  }
+
+  tags = local.tags
+}
+
 module "app_runner_private" {
   source = "../.."
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -150,7 +150,7 @@ module "app_runner_image_base" {
 module "app_runner_private_image_base" {
   source = "../.."
 
-  service_name = "${local.name}-image-base"
+  service_name = "${local.name}-private-image-base"
 
   # Pulling from shared configs
   auto_scaling_configuration_arn = module.app_runner_shared_configs.auto_scaling_configurations["mini"].arn
@@ -167,9 +167,10 @@ module "app_runner_private_image_base" {
       image_repository_type = "ECR"
       image_identifier      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/hello-app-runner:latest"
     }
-    create_access_iam_role = true
-    private_ecr_arn        = "arn:aws:ecr:us-east-1:123456789012:repository/hello-app-runner"
   }
+
+  create_access_iam_role = true
+  private_ecr_arn        = "arn:aws:ecr:us-east-1:123456789012:repository/hello-app-runner"
 
   tags = local.tags
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -153,7 +153,7 @@ module "app_runner_private_image_base" {
   service_name = "${local.name}-image-base"
 
   # Pulling from shared configs
-  auto_scaling_configuration_arn = module.app_runner_shared_configs.auto_scaling_configurations["min"].arn
+  auto_scaling_configuration_arn = module.app_runner_shared_configs.auto_scaling_configurations["mini"].arn
 
   source_configuration = {
     auto_deployments_enabled = false
@@ -164,11 +164,11 @@ module "app_runner_private_image_base" {
           MY_VARIABLE = "hello!"
         }
       }
-      create_access_iam_role  = true
-      image_repository_type   = "ECR"
-      image_identifier        = "12345678912.dkr.ecr.us-east-1.amazonaws.com/hello-app-runner:latest"
-      private_ecr_arn         = "arn:aws:ecr:us-east-1:123456789012:repository/hello-app-runner"
+      image_repository_type = "ECR"
+      image_identifier      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/hello-app-runner:latest"
     }
+    create_access_iam_role = true
+    private_ecr_arn        = "arn:aws:ecr:us-east-1:123456789012:repository/hello-app-runner"
   }
 
   tags = local.tags

--- a/main.tf
+++ b/main.tf
@@ -8,16 +8,16 @@ locals {
   create_service = var.create && var.create_service
 
   # Ensure instance role created is attached even if no values are provided via `var.instance_configuration`
-  instance_configuration = local.create_instance_iam_role ? merge(
+  instance_configuration = try(local.create_instance_iam_role ? merge(
     var.instance_configuration,
     { instance_role_arn = aws_iam_role.instance[0].arn }
-  ) : var.instance_configuration
+  ) : tomap(false), var.instance_configuration)
 
   # Ensure access role created is attached even if no values are provided via `var.source_configuration`
-  source_configuration = local.create_access_iam_role ? merge(
+  source_configuration = try(local.create_access_iam_role ? merge(
     var.source_configuration,
     { authentication_configuration = { access_role_arn = aws_iam_role.access[0].arn } }
-  ) : var.source_configuration
+  ) : tomap(false), var.source_configuration)
 
   # Ensure VPC connector created is attached even if no values are provided via `var.network_configuration`
   network_configuration = local.create_vpc_connector ? merge(


### PR DESCRIPTION
## Description

This pull request aims to fix an issue when configuring a custom access role for AWS App Runner, where the Terraform merge function would return an "Inconsistent conditional result types fail for complex types" error. This occurred because the possibility of adding more attributes in a map was not being handled properly.

```
{
  "@level": "error",
  "@message": "Error: Inconsistent conditional result types",
  "diagnostic": {
    "severity": "error",
    "summary": "Inconsistent conditional result types",
    "detail": "The true and false result expressions must have consistent types. The 'true' value includes object attribute \"authentication_configuration\", which is absent in the 'false' value.",
    "snippet": {
      "context": "locals",
      "code": "  source_configuration = local.create_access_iam_role ? merge(\n    var.source_configuration,\n    { authentication_configuration = { access_role_arn = aws_iam_role.access[0].arn } }\n  ) : var.source_configuration",
      "values": [
        {
          "traversal": "aws_iam_role.access[0].arn",
          "statement": "is a string"
        },
        {
          "traversal": "local.create_access_iam_role",
          "statement": "is true"
        },
        {
          "traversal": "var.source_configuration",
          "statement": "is object with 2 attributes"
        }
      ]
    }
  }
}

```

## Motivation and Context

This change is required to ensure that users can configure custom access roles for AWS App Runner without encountering errors during the merge function. By handling the addition of more attributes in a map, the Terraform configuration will now function correctly and prevent the aforementioned error.

## Breaking Changes

There are no breaking changes in this pull request. The changes are solely focused on resolving the issue mentioned above.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

To test these changes, I started with an existing example from the examples/* folder and deployed it. Then, I applied my changes and checked it against the deployed example to ensure there were no breaking or disruptive changes. Once verified, I deployed the changes again to validate their functionality. Finally, I executed pre-commit run -a on my pull request to ensure compliance with pre-commit standards.
