### PR TITLE
feat: Enable support for ip_address_type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,8 @@ resource "aws_apprunner_service" "this" {
           vpc_connector_arn = try(egress_configuration.value.vpc_connector_arn, null)
         }
       }
+
+      ip_address_type = try(network_configuration.ip_address_type, "IPV4")
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Enable support for [ip_address_type](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_service#network-configuration).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current module version doesn't support IPv6 IP address. This configuration is already available in the terraform resource.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
